### PR TITLE
feat: Phase 10 article experience — accessibility, keyboard nav, mobile TOC, selection toolbar

### DIFF
--- a/src/components/ArticleToc.astro
+++ b/src/components/ArticleToc.astro
@@ -2,14 +2,106 @@
 import { t } from '../lib/i18n.ts';
 ---
 
-<aside class="article-toc-shell" data-article-toc hidden aria-label={t('toc.aria')} data-i18n-aria-label="toc.aria">
+<aside id="article-toc-panel" class="article-toc-shell" data-article-toc hidden aria-label={t('toc.aria')} data-i18n-aria-label="toc.aria">
     <div class="article-progress" aria-hidden="true">
         <span data-reading-progress-bar></span>
     </div>
     <details class="article-toc" open>
         <summary class="article-toc__summary"><span data-i18n="toc.summary">{t('toc.summary')}</span> <span data-reading-progress-text>0%</span></summary>
         <nav aria-label={t('toc.sectionsAria')} data-i18n-aria-label="toc.sectionsAria">
-            <ol class="article-toc__list" data-article-toc-list></ol>
+            <ol class="article-toc__list" data-article-toc-list role="list"></ol>
         </nav>
     </details>
 </aside>
+<button
+    class="article-toc-toggle"
+    type="button"
+    data-article-toc-toggle
+    aria-label={t('toc.toggleAria')}
+    data-i18n-aria-label="toc.toggleAria"
+    aria-controls="article-toc-panel"
+    aria-expanded="false"
+>
+    <svg width="24" height="24" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" aria-hidden="true" focusable="false">
+        <path d="M4 6h16M4 12h16M4 18h16"></path>
+    </svg>
+</button>
+
+<script>
+    const MOBILE_TOC_QUERY = '(max-width: 768px)';
+
+    function getCurrentTocElements() {
+        const tocShell = document.querySelector('[data-article-toc]');
+        const tocToggle = document.querySelector('[data-article-toc-toggle]');
+        return { tocShell, tocToggle };
+    }
+
+    function setTocToggleState(tocShell, tocToggle) {
+        if (!tocShell || !tocToggle) {
+            return;
+        }
+
+        const isExpanded = !tocShell.hidden && !tocShell.classList.contains('is-collapsed');
+        tocToggle.setAttribute('aria-expanded', String(isExpanded));
+    }
+
+    function syncMobileTocState() {
+        const { tocShell, tocToggle } = getCurrentTocElements();
+        if (!tocShell || !tocToggle) {
+            return;
+        }
+
+        const isMobile = window.matchMedia(MOBILE_TOC_QUERY).matches;
+        if (!isMobile || tocShell.hidden) {
+            tocShell.classList.remove('is-collapsed');
+            delete tocShell.dataset.articleTocUserToggled;
+            setTocToggleState(tocShell, tocToggle);
+            return;
+        }
+
+        tocShell.querySelector('.article-toc')?.setAttribute('open', '');
+        if (tocShell.dataset.articleTocUserToggled !== 'true') {
+            tocShell.classList.add('is-collapsed');
+        }
+        setTocToggleState(tocShell, tocToggle);
+    }
+
+    function initArticleTocToggle() {
+        if (document.documentElement.dataset.articleTocToggleBound === 'true') {
+            syncMobileTocState();
+            return;
+        }
+
+        document.documentElement.dataset.articleTocToggleBound = 'true';
+        document.addEventListener('click', (event) => {
+            const { tocShell, tocToggle } = getCurrentTocElements();
+            if (!tocShell || !tocToggle || tocShell.hidden || !window.matchMedia(MOBILE_TOC_QUERY).matches) {
+                return;
+            }
+
+            const target = event.target;
+            if (!(target instanceof Element)) {
+                return;
+            }
+
+            if (tocToggle.contains(target)) {
+                tocShell.dataset.articleTocUserToggled = 'true';
+                tocShell.classList.toggle('is-collapsed');
+                setTocToggleState(tocShell, tocToggle);
+                return;
+            }
+
+            if (tocShell.contains(target) && !target.closest?.('[data-toc-link]')) {
+                return;
+            }
+
+            tocShell.classList.add('is-collapsed');
+            setTocToggleState(tocShell, tocToggle);
+        });
+        window.addEventListener('resize', syncMobileTocState);
+        document.addEventListener('astro:page-load', syncMobileTocState);
+        syncMobileTocState();
+    }
+
+    initArticleTocToggle();
+</script>

--- a/src/components/ArticleToc.astro
+++ b/src/components/ArticleToc.astro
@@ -2,7 +2,7 @@
 import { t } from '../lib/i18n.ts';
 ---
 
-<aside id="article-toc-panel" class="article-toc-shell" data-article-toc hidden aria-label={t('toc.aria')} data-i18n-aria-label="toc.aria">
+<aside id="article-toc-panel" class="article-toc-shell" data-article-toc hidden role="complementary" aria-label={t('toc.aria')} data-i18n-aria-label="toc.aria">
     <div class="article-progress" aria-hidden="true">
         <span data-reading-progress-bar></span>
     </div>

--- a/src/i18n/en-US.json
+++ b/src/i18n/en-US.json
@@ -359,7 +359,12 @@
         "lightboxZoomIn": "Zoom in",
         "lightboxClose": "Close image preview",
         "lightboxAria": "Image viewer",
-        "lightboxDefaultAlt": "Article image"
+        "lightboxDefaultAlt": "Article image",
+        "selectionToolbarAria": "Selected text toolbar",
+        "selectionCopy": "Copy",
+        "selectionShare": "Share",
+        "selectionCopied": "Copied",
+        "selectionLinkCopied": "Link copied"
     },
     "newPost": {
         "pageTitle": "New Article - Calvin Xia",

--- a/src/i18n/en-US.json
+++ b/src/i18n/en-US.json
@@ -357,7 +357,9 @@
         "lightboxZoomOut": "Zoom out",
         "lightboxReset": "Reset zoom",
         "lightboxZoomIn": "Zoom in",
-        "lightboxClose": "Close image preview"
+        "lightboxClose": "Close image preview",
+        "lightboxAria": "Image viewer",
+        "lightboxDefaultAlt": "Article image"
     },
     "newPost": {
         "pageTitle": "New Article - Calvin Xia",

--- a/src/i18n/en-US.json
+++ b/src/i18n/en-US.json
@@ -343,7 +343,8 @@
     "toc": {
         "aria": "Article table of contents",
         "summary": "Contents",
-        "sectionsAria": "Article sections"
+        "sectionsAria": "Article sections",
+        "toggleAria": "Toggle table of contents"
     },
     "transition": {
         "loadingAria": "Page loading"

--- a/src/i18n/zh-CN.json
+++ b/src/i18n/zh-CN.json
@@ -357,7 +357,9 @@
         "lightboxZoomOut": "缩小图片",
         "lightboxReset": "重置缩放",
         "lightboxZoomIn": "放大图片",
-        "lightboxClose": "关闭图片预览"
+        "lightboxClose": "关闭图片预览",
+        "lightboxAria": "图片查看器",
+        "lightboxDefaultAlt": "文章图片"
     },
     "newPost": {
         "pageTitle": "新建文章 - Calvin Xia",

--- a/src/i18n/zh-CN.json
+++ b/src/i18n/zh-CN.json
@@ -343,7 +343,8 @@
     "toc": {
         "aria": "文章目录",
         "summary": "目录",
-        "sectionsAria": "文章章节"
+        "sectionsAria": "文章章节",
+        "toggleAria": "切换目录"
     },
     "transition": {
         "loadingAria": "页面加载中"

--- a/src/i18n/zh-CN.json
+++ b/src/i18n/zh-CN.json
@@ -359,7 +359,12 @@
         "lightboxZoomIn": "放大图片",
         "lightboxClose": "关闭图片预览",
         "lightboxAria": "图片查看器",
-        "lightboxDefaultAlt": "文章图片"
+        "lightboxDefaultAlt": "文章图片",
+        "selectionToolbarAria": "选中文本工具栏",
+        "selectionCopy": "复制",
+        "selectionShare": "分享",
+        "selectionCopied": "已复制",
+        "selectionLinkCopied": "链接已复制"
     },
     "newPost": {
         "pageTitle": "新建文章 - Calvin Xia",

--- a/src/lib/article-enhancements/article-enhancements.js
+++ b/src/lib/article-enhancements/article-enhancements.js
@@ -49,9 +49,9 @@ export function initArticleEnhancements(root = document) {
         windowRef: documentRef.defaultView || window,
     });
     const cleanup = () => {
-        selectionToolbarCleanup();
-        progressCleanup();
-        sectionRevealCleanup();
+        for (const fn of [selectionToolbarCleanup, progressCleanup, sectionRevealCleanup]) {
+            try { fn(); } catch {}
+        }
         enhancementCleanups.delete(documentRef);
     };
 

--- a/src/lib/article-enhancements/article-enhancements.js
+++ b/src/lib/article-enhancements/article-enhancements.js
@@ -2,6 +2,7 @@ import { enhanceArticleImageCaptions } from '../article-image-captions.js';
 import { buildHeadingIndex } from './heading-index.js';
 import { initImageLightbox } from './image-lightbox.js';
 import { initReadingProgress } from './reading-progress.js';
+import { initSelectionToolbar } from './selection-toolbar.js';
 import { initSectionReveals } from './section-reveals.js';
 
 const enhancementCleanups = new WeakMap();
@@ -34,6 +35,9 @@ export function initArticleEnhancements(root = document) {
     enhanceArticleImageCaptions(markdownContent, documentRef);
     const headings = buildHeadingIndex(markdownContent, documentRef);
     initImageLightbox(markdownContent, { documentRef });
+    const selectionToolbarCleanup = initSelectionToolbar(markdownContent, {
+        windowRef: documentRef.defaultView || window,
+    });
     const progressCleanup = initReadingProgress({
         tocRoot,
         contentRoot: markdownContent,
@@ -45,6 +49,7 @@ export function initArticleEnhancements(root = document) {
         windowRef: documentRef.defaultView || window,
     });
     const cleanup = () => {
+        selectionToolbarCleanup();
         progressCleanup();
         sectionRevealCleanup();
         enhancementCleanups.delete(documentRef);

--- a/src/lib/article-enhancements/heading-index.js
+++ b/src/lib/article-enhancements/heading-index.js
@@ -65,6 +65,56 @@ function appendHeadingAnchor(heading, documentRef, text) {
     heading.appendChild(anchor);
 }
 
+export function addTocAccessibility(tocList) {
+    if (!tocList?.querySelectorAll) {
+        return;
+    }
+
+    tocList.setAttribute?.('role', 'list');
+    tocList.setAttribute?.('aria-label', t('toc.aria'));
+    tocList.querySelectorAll('a').forEach((link) => {
+        link.setAttribute?.('role', 'link');
+        link.setAttribute?.('tabindex', '0');
+    });
+}
+
+export function bindTocKeyboardEvents(tocList, documentRef = tocList?.ownerDocument || globalThis.document) {
+    if (!tocList?.querySelectorAll || !tocList?.addEventListener || tocList.dataset?.tocKeyboardBound === 'true') {
+        return;
+    }
+
+    if (tocList.dataset) {
+        tocList.dataset.tocKeyboardBound = 'true';
+    }
+
+    tocList.addEventListener('keydown', (event) => {
+        const links = Array.from(tocList.querySelectorAll('a'));
+        if (!links.length) {
+            return;
+        }
+
+        const activeElement = documentRef?.activeElement;
+        const currentIndex = Math.max(0, links.indexOf(activeElement));
+
+        if (event.key === 'ArrowDown') {
+            event.preventDefault();
+            links[(currentIndex + 1) % links.length].focus();
+            return;
+        }
+
+        if (event.key === 'ArrowUp') {
+            event.preventDefault();
+            links[(currentIndex - 1 + links.length) % links.length].focus();
+            return;
+        }
+
+        if (event.key === 'Enter' && links.includes(activeElement)) {
+            event.preventDefault();
+            activeElement.click?.();
+        }
+    });
+}
+
 export function buildHeadingIndex(root, documentRef = document) {
     if (!root?.querySelectorAll) {
         return [];

--- a/src/lib/article-enhancements/image-lightbox.js
+++ b/src/lib/article-enhancements/image-lightbox.js
@@ -8,6 +8,10 @@ const TRUSTED_IMAGE_HOSTS = new Set([
     'content.calvin-xia.cn',
 ]);
 
+function clamp(value, min, max) {
+    return Math.min(max, Math.max(min, value));
+}
+
 function getAttributeValue(element, name) {
     return element?.getAttribute?.(name) || element?.[name] || '';
 }
@@ -209,8 +213,8 @@ export function createLightboxController({ documentRef = document } = {}) {
             return;
         }
 
-        const x = clampScale(((center.x - rect.left) / rect.width) * 100, 0, 100);
-        const y = clampScale(((center.y - rect.top) / rect.height) * 100, 0, 100);
+        const x = clamp(((center.x - rect.left) / rect.width) * 100, 0, 100);
+        const y = clamp(((center.y - rect.top) / rect.height) * 100, 0, 100);
         state.imageNode.style.transformOrigin = `${x}% ${y}%`;
     }
 
@@ -375,6 +379,10 @@ export function createLightboxController({ documentRef = document } = {}) {
             if (event.touches?.length >= 2) {
                 state.touchDistance = getTouchDistance(event);
                 state.touchStartScale = state.scale;
+                return;
+            }
+
+            if (!state.isPinching) {
                 return;
             }
 

--- a/src/lib/article-enhancements/image-lightbox.js
+++ b/src/lib/article-enhancements/image-lightbox.js
@@ -309,11 +309,13 @@ export function createLightboxController({ documentRef = document } = {}) {
         dialog.setAttribute('aria-label', t('articleEnhancements.lightboxAria'));
         dialog.setAttribute('aria-modal', 'true');
         dialog.setAttribute('aria-keyshortcuts', 'Escape ArrowLeft ArrowRight + -');
+        dialog.setAttribute('aria-describedby', 'article-lightbox-caption');
         frame.classList.add('article-lightbox__frame');
         toolbar.classList.add('article-lightbox__toolbar');
         figure.classList.add('article-lightbox__figure');
         image.classList.add('article-lightbox__image');
         caption.classList.add('article-lightbox__caption');
+        caption.setAttribute('id', 'article-lightbox-caption');
 
         toolbar.append(previousButton, zoomOutButton, resetButton, zoomInButton, nextButton, closeButton);
         figure.append(image, caption);

--- a/src/lib/article-enhancements/image-lightbox.js
+++ b/src/lib/article-enhancements/image-lightbox.js
@@ -2,8 +2,7 @@ import { t } from '../i18n.ts';
 
 const MIN_SCALE = 1;
 const MAX_SCALE = 4;
-const SCALE_STEP = 0.25;
-const TOUCH_SCALE_SENSITIVITY = 240;
+const SCALE_STEP = 0.5;
 const TRUSTED_IMAGE_HOSTS = new Set([
     'assets.calvin-xia.cn',
     'content.calvin-xia.cn',
@@ -34,6 +33,17 @@ function createButton(documentRef, className, label, text) {
 
 export function clampScale(value, min = MIN_SCALE, max = MAX_SCALE) {
     return Math.min(max, Math.max(min, Number(value) || min));
+}
+
+export function calculatePinchScale({ startScale, startDistance, currentDistance }) {
+    const initialDistance = Number(startDistance);
+    const nextDistance = Number(currentDistance);
+
+    if (!initialDistance || !nextDistance || initialDistance <= 0 || nextDistance <= 0) {
+        return clampScale(startScale);
+    }
+
+    return clampScale((Number(startScale) || MIN_SCALE) * (nextDistance / initialDistance));
 }
 
 export function getImageCaption(image) {
@@ -97,6 +107,8 @@ export function createLightboxController({ documentRef = document } = {}) {
         scale: 1,
         sourceImage: null,
         touchDistance: 0,
+        touchStartScale: 1,
+        isPinching: false,
     };
 
     function updateScale() {
@@ -127,7 +139,7 @@ export function createLightboxController({ documentRef = document } = {}) {
 
         state.sourceImage = image;
         state.imageNode.setAttribute('src', source);
-        state.imageNode.setAttribute('alt', getAttributeValue(image, 'alt') || caption);
+        state.imageNode.setAttribute('alt', getAttributeValue(image, 'alt') || caption || t('articleEnhancements.lightboxDefaultAlt'));
         state.captionNode.textContent = caption;
         setButtonDisabled(state.previousButton, state.images.length < 2);
         setButtonDisabled(state.nextButton, state.images.length < 2);
@@ -167,13 +179,94 @@ export function createLightboxController({ documentRef = document } = {}) {
         renderCurrentImage();
     }
 
-    function touchDistance(event) {
+    function getTouchDistance(event) {
         if (!event.touches || event.touches.length < 2) {
             return 0;
         }
 
         const [first, second] = event.touches;
         return Math.hypot(first.clientX - second.clientX, first.clientY - second.clientY);
+    }
+
+    function getTouchCenter(event) {
+        if (!event.touches || event.touches.length < 2) {
+            return null;
+        }
+
+        const [first, second] = event.touches;
+        return {
+            x: (first.clientX + second.clientX) / 2,
+            y: (first.clientY + second.clientY) / 2,
+        };
+    }
+
+    function updateTouchTransformOrigin(event) {
+        const center = getTouchCenter(event);
+        const rect = state.imageNode?.getBoundingClientRect?.();
+
+        if (!center || !rect || !rect.width || !rect.height) {
+            state.imageNode.style.transformOrigin = 'center center';
+            return;
+        }
+
+        const x = clampScale(((center.x - rect.left) / rect.width) * 100, 0, 100);
+        const y = clampScale(((center.y - rect.top) / rect.height) * 100, 0, 100);
+        state.imageNode.style.transformOrigin = `${x}% ${y}%`;
+    }
+
+    function focusableElements() {
+        return Array.from(state.dialog?.querySelectorAll?.(
+            'button, [href], input, select, textarea, [tabindex]:not([tabindex="-1"])',
+        ) || []).filter((element) => !element.disabled && element.getAttribute?.('aria-hidden') !== 'true');
+    }
+
+    function trapFocus(event) {
+        const elements = focusableElements();
+        if (!elements.length) {
+            return false;
+        }
+
+        const firstElement = elements[0];
+        const lastElement = elements[elements.length - 1];
+        const activeElement = documentRef.activeElement;
+
+        if (event.shiftKey && activeElement === firstElement) {
+            event.preventDefault();
+            lastElement.focus();
+            return true;
+        }
+
+        if (!event.shiftKey && activeElement === lastElement) {
+            event.preventDefault();
+            firstElement.focus();
+            return true;
+        }
+
+        return false;
+    }
+
+    function handleDialogKeydown(event) {
+        if (event.key === 'Tab') {
+            trapFocus(event);
+            return;
+        }
+
+        const handlers = {
+            Escape: close,
+            ArrowLeft: showPrevious,
+            ArrowRight: showNext,
+            '+': () => setScale(state.scale + SCALE_STEP),
+            '=': () => setScale(state.scale + SCALE_STEP),
+            '-': () => setScale(state.scale - SCALE_STEP),
+        };
+        const handler = handlers[event.key];
+
+        if (!handler) {
+            return;
+        }
+
+        event.preventDefault();
+        handler();
     }
 
     function isFrameOutsideClick(event) {
@@ -212,6 +305,8 @@ export function createLightboxController({ documentRef = document } = {}) {
         const closeButton = createButton(documentRef, 'article-lightbox__button--close', t('articleEnhancements.lightboxClose'), 'x');
 
         dialog.classList.add('article-lightbox');
+        dialog.setAttribute('role', 'dialog');
+        dialog.setAttribute('aria-label', t('articleEnhancements.lightboxAria'));
         dialog.setAttribute('aria-modal', 'true');
         frame.classList.add('article-lightbox__frame');
         toolbar.classList.add('article-lightbox__toolbar');
@@ -240,23 +335,50 @@ export function createLightboxController({ documentRef = document } = {}) {
                 close();
             }
         });
+        dialog.addEventListener('keydown', handleDialogKeydown);
         dialog.addEventListener('wheel', (event) => {
             event.preventDefault();
             setScale(state.scale + (event.deltaY < 0 ? SCALE_STEP : -SCALE_STEP));
         }, { passive: false });
         image.addEventListener('touchstart', (event) => {
-            state.touchDistance = touchDistance(event);
+            if (event.touches?.length !== 2) {
+                return;
+            }
+
+            state.isPinching = true;
+            state.touchDistance = getTouchDistance(event);
+            state.touchStartScale = state.scale;
+            updateTouchTransformOrigin(event);
         }, { passive: true });
         image.addEventListener('touchmove', (event) => {
-            const nextDistance = touchDistance(event);
+            if (!state.isPinching || event.touches?.length !== 2) {
+                return;
+            }
+
+            const nextDistance = getTouchDistance(event);
             if (!state.touchDistance || !nextDistance) {
                 return;
             }
 
             event.preventDefault();
-            setScale(state.scale + (nextDistance - state.touchDistance) / TOUCH_SCALE_SENSITIVITY);
-            state.touchDistance = nextDistance;
+            updateTouchTransformOrigin(event);
+            setScale(calculatePinchScale({
+                startScale: state.touchStartScale,
+                startDistance: state.touchDistance,
+                currentDistance: nextDistance,
+            }));
         }, { passive: false });
+        image.addEventListener('touchend', (event) => {
+            if (event.touches?.length >= 2) {
+                state.touchDistance = getTouchDistance(event);
+                state.touchStartScale = state.scale;
+                return;
+            }
+
+            state.isPinching = false;
+            state.touchDistance = 0;
+            state.touchStartScale = state.scale;
+        }, { passive: true });
 
         state.captionNode = caption;
         state.closeButton = closeButton;

--- a/src/lib/article-enhancements/image-lightbox.js
+++ b/src/lib/article-enhancements/image-lightbox.js
@@ -308,6 +308,7 @@ export function createLightboxController({ documentRef = document } = {}) {
         dialog.setAttribute('role', 'dialog');
         dialog.setAttribute('aria-label', t('articleEnhancements.lightboxAria'));
         dialog.setAttribute('aria-modal', 'true');
+        dialog.setAttribute('aria-keyshortcuts', 'Escape ArrowLeft ArrowRight + -');
         frame.classList.add('article-lightbox__frame');
         toolbar.classList.add('article-lightbox__toolbar');
         figure.classList.add('article-lightbox__figure');

--- a/src/lib/article-enhancements/reading-progress.js
+++ b/src/lib/article-enhancements/reading-progress.js
@@ -1,3 +1,4 @@
+const MOBILE_TOC_BREAKPOINT = 768;
 const MIN_TOC_HEADINGS = 3;
 const TOC_ACTIVE_SCROLL_PADDING = 12;
 const tocCleanupCallbacks = new WeakMap();
@@ -16,7 +17,7 @@ export function shouldRenderToc(entries, minHeadings = MIN_TOC_HEADINGS) {
     return Array.isArray(entries) && entries.length >= minHeadings;
 }
 
-export function shouldCollapseTocForViewport(width, breakpoint = 767) {
+export function shouldCollapseTocForViewport(width, breakpoint = MOBILE_TOC_BREAKPOINT) {
     return Number(width) <= breakpoint;
 }
 
@@ -99,6 +100,15 @@ function setActiveTocItem(tocRoot, activeId) {
     });
 
     keepActiveTocLinkVisible(tocRoot, activeLink);
+}
+
+function setTocToggleExpanded(documentRef, tocRoot, expanded) {
+    const toggle = documentRef.querySelector?.('[data-article-toc-toggle]');
+    if (!toggle || toggle.getAttribute('aria-controls') !== tocRoot.id) {
+        return;
+    }
+
+    toggle.setAttribute('aria-expanded', String(expanded));
 }
 
 function clearTocList(list) {
@@ -201,11 +211,10 @@ export function initReadingProgress({
 
     const details = tocRoot.querySelector?.('.article-toc');
     const syncTocDisclosure = () => {
-        if (details && shouldCollapseTocForViewport(windowRef.innerWidth)) {
-            details.removeAttribute('open');
-        } else {
-            details?.setAttribute?.('open', '');
-        }
+        const shouldCollapse = shouldCollapseTocForViewport(windowRef.innerWidth);
+        details?.setAttribute?.('open', '');
+        tocRoot.classList?.toggle?.('is-collapsed', shouldCollapse);
+        setTocToggleExpanded(documentRef, tocRoot, !shouldCollapse);
     };
     syncTocDisclosure();
 
@@ -243,6 +252,11 @@ export function initReadingProgress({
             const targetId = link.getAttribute('href')?.slice(1);
             if (targetId) {
                 windowRef.history?.replaceState?.(null, '', `#${targetId}`);
+            }
+
+            if (shouldCollapseTocForViewport(windowRef.innerWidth)) {
+                tocRoot.classList?.add?.('is-collapsed');
+                setTocToggleExpanded(documentRef, tocRoot, false);
             }
         });
     });

--- a/src/lib/article-enhancements/reading-progress.js
+++ b/src/lib/article-enhancements/reading-progress.js
@@ -1,3 +1,5 @@
+import { addTocAccessibility, bindTocKeyboardEvents } from './heading-index.js';
+
 const MOBILE_TOC_BREAKPOINT = 768;
 const MIN_TOC_HEADINGS = 3;
 const TOC_ACTIVE_SCROLL_PADDING = 12;
@@ -137,6 +139,9 @@ function renderTocList(tocRoot, entries, documentRef) {
         listItem.appendChild(link);
         list.appendChild(listItem);
     });
+
+    addTocAccessibility(list);
+    bindTocKeyboardEvents(list, documentRef);
 }
 
 function findCurrentHeadingId(headings) {

--- a/src/lib/article-enhancements/selection-toolbar.js
+++ b/src/lib/article-enhancements/selection-toolbar.js
@@ -1,0 +1,244 @@
+import { t } from '../i18n.ts';
+
+const TOOLBAR_OFFSET = 10;
+const VIEWPORT_PADDING = 8;
+const toolbarCleanups = new WeakMap();
+
+function elementFromNode(node) {
+    if (!node) {
+        return null;
+    }
+
+    return node.nodeType === 1 ? node : node.parentElement;
+}
+
+function selectionBelongsToContainer(selection, container) {
+    const anchor = elementFromNode(selection?.anchorNode);
+    const focus = elementFromNode(selection?.focusNode);
+
+    return Boolean(anchor && container.contains(anchor) && (!focus || container.contains(focus)));
+}
+
+function selectedText(selection) {
+    return selection?.toString?.().trim() || '';
+}
+
+function createToolbarButton(documentRef, action, key) {
+    const button = documentRef.createElement('button');
+    button.type = 'button';
+    button.className = 'selection-toolbar-btn';
+    button.dataset.action = action;
+    button.dataset.i18n = key;
+    button.textContent = t(key);
+    return button;
+}
+
+function createToolbarElement(documentRef) {
+    const toolbar = documentRef.createElement('div');
+    toolbar.className = 'selection-toolbar';
+    toolbar.setAttribute('role', 'toolbar');
+    toolbar.setAttribute('aria-label', t('articleEnhancements.selectionToolbarAria'));
+    toolbar.setAttribute('data-i18n-aria-label', 'articleEnhancements.selectionToolbarAria');
+    toolbar.append(
+        createToolbarButton(documentRef, 'copy', 'articleEnhancements.selectionCopy'),
+        createToolbarButton(documentRef, 'share', 'articleEnhancements.selectionShare'),
+    );
+    return toolbar;
+}
+
+function clamp(value, min, max) {
+    return Math.min(max, Math.max(min, value));
+}
+
+function positionToolbar(toolbar, rect, windowRef) {
+    const toolbarWidth = toolbar.offsetWidth || 132;
+    const left = clamp(
+        rect.left + (rect.width / 2),
+        VIEWPORT_PADDING + (toolbarWidth / 2),
+        Math.max(VIEWPORT_PADDING + (toolbarWidth / 2), windowRef.innerWidth - VIEWPORT_PADDING - (toolbarWidth / 2)),
+    );
+    const top = rect.top - toolbar.offsetHeight - TOOLBAR_OFFSET;
+
+    toolbar.style.left = `${left}px`;
+    toolbar.style.top = `${top >= VIEWPORT_PADDING ? top : rect.bottom + TOOLBAR_OFFSET}px`;
+}
+
+function showToolbar(toolbar, selection, windowRef, state) {
+    if (!selection?.rangeCount) {
+        hideToolbar(toolbar);
+        return;
+    }
+
+    const text = selectedText(selection);
+    const range = selection.getRangeAt(0);
+    const rect = range.getBoundingClientRect();
+
+    if (!text || !rect || (!rect.width && !rect.height)) {
+        hideToolbar(toolbar);
+        return;
+    }
+
+    state.selectedText = text;
+    state.anchorNode = selection.anchorNode;
+    positionToolbar(toolbar, rect, windowRef);
+    toolbar.classList.add('is-visible');
+}
+
+function hideToolbar(toolbar) {
+    toolbar.classList.remove('is-visible');
+}
+
+async function writeClipboard(text, windowRef) {
+    if (windowRef.navigator?.clipboard?.writeText) {
+        await windowRef.navigator.clipboard.writeText(text);
+        return true;
+    }
+
+    return false;
+}
+
+function showFeedback(documentRef, message) {
+    documentRef.querySelector?.('[data-selection-toolbar-feedback]')?.remove?.();
+
+    const feedback = documentRef.createElement('div');
+    feedback.className = 'selection-toolbar-feedback';
+    feedback.setAttribute('role', 'status');
+    feedback.setAttribute('aria-live', 'polite');
+    feedback.setAttribute('data-selection-toolbar-feedback', '');
+    feedback.textContent = message;
+    documentRef.body.appendChild(feedback);
+    setTimeout(() => feedback.remove(), 2000);
+}
+
+function findLastHeading(element) {
+    if (element.matches?.('h1,h2,h3,h4,h5,h6')) {
+        return element;
+    }
+
+    const headings = element.querySelectorAll?.('h1,h2,h3,h4,h5,h6');
+    return headings?.[headings.length - 1] || null;
+}
+
+export function findNearestHeading(node, container) {
+    let current = elementFromNode(node);
+
+    if (!current || !container?.contains?.(current)) {
+        return null;
+    }
+
+    const ownHeading = current.closest?.('h1,h2,h3,h4,h5,h6');
+    if (ownHeading && container.contains(ownHeading)) {
+        return ownHeading;
+    }
+
+    while (current && current !== container) {
+        let sibling = current.previousElementSibling;
+        while (sibling) {
+            const heading = findLastHeading(sibling);
+            if (heading) {
+                return heading;
+            }
+            sibling = sibling.previousElementSibling;
+        }
+        current = current.parentElement;
+    }
+
+    return null;
+}
+
+function buildShareUrl(windowRef, heading) {
+    const url = new URL(windowRef.location.href);
+    url.hash = heading?.id || '';
+    return url.toString();
+}
+
+export function initSelectionToolbar(container, { windowRef = container?.ownerDocument?.defaultView || window } = {}) {
+    if (!container?.appendChild || !container?.addEventListener) {
+        return () => {};
+    }
+
+    toolbarCleanups.get(container)?.();
+
+    const documentRef = container.ownerDocument || windowRef.document;
+    const toolbar = createToolbarElement(documentRef);
+    const state = {
+        anchorNode: null,
+        selectedText: '',
+    };
+
+    container.appendChild(toolbar);
+
+    const currentSelection = () => windowRef.getSelection?.();
+    const showFromSelection = (event) => {
+        if (event?.target && toolbar.contains(event.target)) {
+            return;
+        }
+
+        const selection = currentSelection();
+        if (!selection || !selectionBelongsToContainer(selection, container)) {
+            hideToolbar(toolbar);
+            return;
+        }
+
+        showToolbar(toolbar, selection, windowRef, state);
+    };
+    const hideUnlessToolbar = (event) => {
+        if (!event?.target || !toolbar.contains(event.target)) {
+            hideToolbar(toolbar);
+        }
+    };
+    const handleToolbarClick = async (event) => {
+        const action = event.target?.closest?.('[data-action]')?.dataset?.action;
+        if (!action) {
+            return;
+        }
+
+        const selection = currentSelection();
+        const text = selectedText(selection) || state.selectedText;
+        if (!text) {
+            hideToolbar(toolbar);
+            return;
+        }
+
+        if (action === 'copy') {
+            await writeClipboard(text, windowRef);
+            showFeedback(documentRef, t('articleEnhancements.selectionCopied'));
+            hideToolbar(toolbar);
+            return;
+        }
+
+        if (action === 'share') {
+            const heading = findNearestHeading(selection?.anchorNode || state.anchorNode, container);
+            await writeClipboard(buildShareUrl(windowRef, heading), windowRef);
+            showFeedback(documentRef, t('articleEnhancements.selectionLinkCopied'));
+            hideToolbar(toolbar);
+        }
+    };
+    const handleKeydown = (event) => {
+        if (event.key === 'Escape') {
+            hideToolbar(toolbar);
+        }
+    };
+    const handleScroll = () => hideToolbar(toolbar);
+
+    container.addEventListener('mouseup', showFromSelection);
+    container.addEventListener('touchend', showFromSelection, { passive: true });
+    container.addEventListener('mousedown', hideUnlessToolbar);
+    toolbar.addEventListener('click', handleToolbarClick);
+    documentRef.addEventListener?.('keydown', handleKeydown);
+    windowRef.addEventListener?.('scroll', handleScroll, { passive: true });
+
+    const cleanup = () => {
+        container.removeEventListener('mouseup', showFromSelection);
+        container.removeEventListener('touchend', showFromSelection);
+        container.removeEventListener('mousedown', hideUnlessToolbar);
+        toolbar.removeEventListener('click', handleToolbarClick);
+        documentRef.removeEventListener?.('keydown', handleKeydown);
+        windowRef.removeEventListener?.('scroll', handleScroll);
+        toolbar.remove();
+        toolbarCleanups.delete(container);
+    };
+
+    toolbarCleanups.set(container, cleanup);
+    return cleanup;
+}

--- a/src/lib/article-enhancements/selection-toolbar.js
+++ b/src/lib/article-enhancements/selection-toolbar.js
@@ -89,10 +89,12 @@ function hideToolbar(toolbar) {
 }
 
 async function writeClipboard(text, windowRef) {
-    if (windowRef.navigator?.clipboard?.writeText) {
-        await windowRef.navigator.clipboard.writeText(text);
-        return true;
-    }
+    try {
+        if (windowRef.navigator?.clipboard?.writeText) {
+            await windowRef.navigator.clipboard.writeText(text);
+            return true;
+        }
+    } catch {}
 
     return false;
 }

--- a/src/styles/global.css
+++ b/src/styles/global.css
@@ -2041,6 +2041,76 @@ select:disabled {
     text-align: center;
 }
 
+.selection-toolbar {
+    position: fixed;
+    z-index: 1000;
+    display: flex;
+    gap: 0.5rem;
+    padding: 0.5rem;
+    border: 1px solid var(--border);
+    border-radius: var(--radius-md);
+    background: var(--surface);
+    box-shadow: var(--shadow-raised);
+    opacity: 0;
+    visibility: hidden;
+    pointer-events: none;
+    transform: translateX(-50%) translateY(-8px);
+    transition:
+        opacity var(--duration-fast) var(--ease-out),
+        visibility var(--duration-fast) var(--ease-out),
+        transform var(--duration-fast) var(--ease-out);
+}
+
+.selection-toolbar.is-visible {
+    opacity: 1;
+    visibility: visible;
+    pointer-events: auto;
+    transform: translateX(-50%) translateY(0);
+}
+
+.selection-toolbar-btn {
+    min-height: 44px;
+    padding: 0.375rem 0.75rem;
+    border: 1px solid var(--border);
+    border-radius: var(--radius-sm);
+    background: var(--surface);
+    color: var(--text);
+    font-size: 0.875rem;
+    line-height: 1.2;
+    cursor: pointer;
+}
+
+.selection-toolbar-btn:hover {
+    border-color: var(--border-hover);
+    background: var(--surface-hover);
+}
+
+.selection-toolbar-feedback {
+    position: fixed;
+    bottom: 2rem;
+    left: 50%;
+    z-index: 1001;
+    padding: 0.5rem 1rem;
+    border-radius: var(--radius-md);
+    background: var(--accent);
+    color: var(--text-inverse);
+    font-size: 0.875rem;
+    transform: translateX(-50%);
+    animation: selectionToolbarFeedback 2s var(--ease-out) both;
+}
+
+@keyframes selectionToolbarFeedback {
+    0%,
+    100% {
+        opacity: 0;
+    }
+
+    20%,
+    80% {
+        opacity: 1;
+    }
+}
+
 .new-post-workbench {
     display: grid;
     gap: 1rem;

--- a/src/styles/global.css
+++ b/src/styles/global.css
@@ -1853,6 +1853,14 @@ select:disabled {
     display: none;
 }
 
+.article-toc-toggle {
+    display: none;
+}
+
+.article-toc-shell[hidden] + .article-toc-toggle {
+    display: none;
+}
+
 .article-progress {
     height: 0.24rem;
     border-radius: var(--radius-pill);
@@ -2510,6 +2518,72 @@ html[data-astro-transition='back']::view-transition-old(site-main) {
 
     .article-lightbox__frame {
         width: calc(100vw - 1rem);
+    }
+}
+
+@media (max-width: 768px) {
+    .article-reading-layout {
+        grid-template-columns: 1fr;
+    }
+
+    .article-toc-shell {
+        position: fixed;
+        right: 0;
+        top: 50%;
+        z-index: 100;
+        width: min(calc(100vw - 4rem), 280px);
+        max-width: 280px;
+        max-height: 80vh;
+        overflow: hidden;
+        transform: translateY(-50%);
+        border: 1px solid var(--border);
+        border-right: 0;
+        border-radius: var(--radius-md) 0 0 var(--radius-md);
+        background: var(--surface);
+        box-shadow: var(--shadow-raised);
+        transition: transform var(--duration-base) var(--ease-out);
+    }
+
+    .article-toc-shell.is-collapsed {
+        transform: translateY(-50%) translateX(100%);
+    }
+
+    .article-toc {
+        max-height: 80vh;
+    }
+
+    .article-toc > nav {
+        max-height: calc(80vh - 4rem);
+    }
+
+    .article-toc-toggle {
+        position: fixed;
+        right: 1rem;
+        bottom: 2rem;
+        z-index: 101;
+        width: 48px;
+        height: 48px;
+        display: flex;
+        align-items: center;
+        justify-content: center;
+        border: 0;
+        border-radius: 50%;
+        padding: 0;
+        background: var(--accent);
+        color: var(--text-inverse);
+        box-shadow: var(--shadow-raised);
+        cursor: pointer;
+    }
+
+    .article-toc-toggle:hover {
+        background: var(--accent-hover);
+        color: var(--text-inverse);
+    }
+}
+
+@media (max-width: 768px) and (prefers-reduced-motion: reduce) {
+    .article-toc-shell {
+        transition: none;
     }
 }
 

--- a/tests/article-headings.test.js
+++ b/tests/article-headings.test.js
@@ -38,8 +38,66 @@ class FakeHeading {
     }
 }
 
+class FakeTocLink {
+    constructor(text) {
+        this.textContent = text;
+        this.attributes = new Map();
+        this.focused = false;
+        this.clicked = false;
+    }
+
+    setAttribute(name, value) {
+        this.attributes.set(name, String(value));
+    }
+
+    getAttribute(name) {
+        return this.attributes.get(name) ?? null;
+    }
+
+    focus() {
+        this.focused = true;
+        this.ownerDocument.activeElement = this;
+    }
+
+    click() {
+        this.clicked = true;
+    }
+}
+
+class FakeTocList {
+    constructor(links, ownerDocument) {
+        this.links = links;
+        this.ownerDocument = ownerDocument;
+        this.attributes = new Map();
+        this.dataset = {};
+        this.listeners = new Map();
+        links.forEach((link) => {
+            link.ownerDocument = ownerDocument;
+        });
+    }
+
+    setAttribute(name, value) {
+        this.attributes.set(name, String(value));
+    }
+
+    getAttribute(name) {
+        return this.attributes.get(name) ?? null;
+    }
+
+    querySelectorAll(selector) {
+        return selector === 'a' ? this.links : [];
+    }
+
+    addEventListener(type, handler) {
+        const handlers = this.listeners.get(type) || [];
+        handlers.push(handler);
+        this.listeners.set(type, handlers);
+    }
+}
+
 function createFakeDocument() {
     return {
+        activeElement: null,
         createElement(tagName) {
             return new FakeHeading(tagName, '');
         },
@@ -91,5 +149,45 @@ describe('article heading index', () => {
         assert.equal(headings[1].querySelector('.heading-anchor').getAttribute('href'), '#重复标题');
         assert.equal(headings[1].querySelector('.heading-anchor').textContent, '#');
         assert.equal(headings[1].dataset.headingIndexed, 'true');
+    });
+
+    test('adds accessible TOC metadata and arrow-key navigation', async () => {
+        const { addTocAccessibility, bindTocKeyboardEvents } = await import('../src/lib/article-enhancements/heading-index.js');
+        const documentRef = createFakeDocument();
+        const links = [
+            new FakeTocLink('第一节'),
+            new FakeTocLink('第二节'),
+            new FakeTocLink('第三节'),
+        ];
+        const tocList = new FakeTocList(links, documentRef);
+        const preventedKeys = [];
+
+        addTocAccessibility(tocList);
+        bindTocKeyboardEvents(tocList, documentRef);
+
+        assert.equal(tocList.getAttribute('role'), 'list');
+        assert.equal(tocList.getAttribute('aria-label'), '文章目录');
+        links.forEach((link) => {
+            assert.equal(link.getAttribute('role'), 'link');
+            assert.equal(link.getAttribute('tabindex'), '0');
+        });
+
+        links[0].focus();
+        const dispatchKey = (key) => tocList.listeners.get('keydown').forEach((handler) => handler({
+            key,
+            preventDefault() {
+                preventedKeys.push(key);
+            },
+        }));
+
+        dispatchKey('ArrowDown');
+        assert.equal(documentRef.activeElement, links[1]);
+
+        dispatchKey('ArrowUp');
+        assert.equal(documentRef.activeElement, links[0]);
+
+        dispatchKey('Enter');
+        assert.equal(links[0].clicked, true);
+        assert.deepEqual(preventedKeys, ['ArrowDown', 'ArrowUp', 'Enter']);
     });
 });

--- a/tests/article-lightbox.test.js
+++ b/tests/article-lightbox.test.js
@@ -205,6 +205,8 @@ describe('article image lightbox', () => {
         assert.equal(dialog.getAttribute('role'), 'dialog');
         assert.equal(dialog.getAttribute('aria-modal'), 'true');
         assert.equal(dialog.getAttribute('aria-label'), '图片查看器');
+        assert.equal(dialog.getAttribute('aria-describedby'), 'article-lightbox-caption');
+        assert.equal(dialog.querySelector('.article-lightbox__caption').getAttribute('id'), 'article-lightbox-caption');
         assert.equal(renderedImage.getAttribute('alt'), '文章图片');
     });
 

--- a/tests/article-lightbox.test.js
+++ b/tests/article-lightbox.test.js
@@ -145,12 +145,67 @@ describe('article image lightbox', () => {
         assert.equal(clampScale(7), 4);
     });
 
-    test('names the touch pinch zoom sensitivity constant', () => {
-        const source = readProjectFile('src', 'lib', 'article-enhancements', 'image-lightbox.js');
+    test('calculates pinch zoom from the initial touch distance without incremental drift', async () => {
+        const { calculatePinchScale } = await import('../src/lib/article-enhancements/image-lightbox.js');
 
-        assert.match(source, /const\s+TOUCH_SCALE_SENSITIVITY\s*=\s*240/);
-        assert.match(source, /\(nextDistance\s*-\s*state\.touchDistance\)\s*\/\s*TOUCH_SCALE_SENSITIVITY/);
-        assert.doesNotMatch(source, /\(nextDistance\s*-\s*state\.touchDistance\)\s*\/\s*240/);
+        assert.equal(calculatePinchScale({ startScale: 1, startDistance: 120, currentDistance: 240 }), 2);
+        assert.equal(calculatePinchScale({ startScale: 2, startDistance: 200, currentDistance: 50 }), 1);
+        assert.equal(calculatePinchScale({ startScale: 3, startDistance: 100, currentDistance: 200 }), 4);
+        assert.equal(calculatePinchScale({ startScale: 2, startDistance: 0, currentDistance: 200 }), 2);
+    });
+
+    test('keyboard shortcuts switch images, zoom, and close the dialog', async () => {
+        const { createLightboxController } = await import('../src/lib/article-enhancements/image-lightbox.js');
+        const documentRef = createFakeDocument();
+        const firstImage = new FakeElement('img', { src: '/storage/first.jpg', alt: 'First image' });
+        const secondImage = new FakeElement('img', { src: '/storage/second.jpg', alt: 'Second image' });
+        const controller = createLightboxController({ documentRef });
+        const preventedKeys = [];
+
+        controller.open(firstImage, [firstImage, secondImage]);
+
+        const dialog = documentRef.body.querySelector('.article-lightbox');
+        const renderedImage = dialog.querySelector('.article-lightbox__image');
+        const keyHandlers = dialog.listeners.get('keydown');
+        const dispatchKey = (key) => keyHandlers.forEach((handler) => handler({
+            key,
+            preventDefault() {
+                preventedKeys.push(key);
+            },
+        }));
+
+        dispatchKey('+');
+        assert.equal(controller.getState().scale, 1.5);
+
+        dispatchKey('-');
+        assert.equal(controller.getState().scale, 1);
+
+        dispatchKey('ArrowRight');
+        assert.equal(renderedImage.getAttribute('src'), '/storage/second.jpg');
+
+        dispatchKey('ArrowLeft');
+        assert.equal(renderedImage.getAttribute('src'), '/storage/first.jpg');
+
+        dispatchKey('Escape');
+        assert.equal(dialog.open, false);
+        assert.deepEqual(preventedKeys, ['+', '-', 'ArrowRight', 'ArrowLeft', 'Escape']);
+    });
+
+    test('creates an accessible image viewer dialog with fallback alt text', async () => {
+        const { createLightboxController } = await import('../src/lib/article-enhancements/image-lightbox.js');
+        const documentRef = createFakeDocument();
+        const image = new FakeElement('img', { src: '/storage/photo.jpg' });
+        const controller = createLightboxController({ documentRef });
+
+        controller.open(image, [image]);
+
+        const dialog = documentRef.body.querySelector('.article-lightbox');
+        const renderedImage = dialog.querySelector('.article-lightbox__image');
+
+        assert.equal(dialog.getAttribute('role'), 'dialog');
+        assert.equal(dialog.getAttribute('aria-modal'), 'true');
+        assert.equal(dialog.getAttribute('aria-label'), '图片查看器');
+        assert.equal(renderedImage.getAttribute('alt'), '文章图片');
     });
 
     test('uses figure captions before image alt text', async () => {
@@ -286,6 +341,6 @@ describe('article image lightbox', () => {
         assert.equal(renderedImage.getAttribute('src'), '/storage/photo.jpg');
         assert.equal(dialog.open, false);
         assert.equal(image.focused, true);
-        assert.equal(controller.getState().scale, 1.25);
+        assert.equal(controller.getState().scale, 1.5);
     });
 });

--- a/tests/article-lightbox.test.js
+++ b/tests/article-lightbox.test.js
@@ -1,13 +1,5 @@
 import assert from 'node:assert/strict';
-import { readFileSync } from 'node:fs';
-import path from 'node:path';
 import { describe, test } from 'node:test';
-
-const rootDir = path.resolve(import.meta.dirname, '..');
-
-function readProjectFile(...segments) {
-    return readFileSync(path.join(rootDir, ...segments), 'utf8');
-}
 
 class FakeElement {
     constructor(tagName, attributes = {}) {

--- a/tests/article-lightbox.test.js
+++ b/tests/article-lightbox.test.js
@@ -345,4 +345,32 @@ describe('article image lightbox', () => {
         assert.equal(image.focused, true);
         assert.equal(controller.getState().scale, 1.5);
     });
+
+    test('single-finger touchend does not reset touchStartScale when not pinching', async () => {
+        const { createLightboxController } = await import('../src/lib/article-enhancements/image-lightbox.js');
+        const documentRef = createFakeDocument();
+        const image = new FakeElement('img', { src: '/storage/photo.jpg', alt: 'Photo' });
+        const controller = createLightboxController({ documentRef });
+
+        controller.open(image, [image]);
+        controller.zoomIn();
+        controller.zoomIn();
+
+        const dialog = documentRef.body.querySelector('.article-lightbox');
+        const renderedImage = dialog.querySelector('.article-lightbox__image');
+        const touchEndHandlers = renderedImage.listeners.get('touchend');
+
+        assert.ok(touchEndHandlers, 'touchend handlers should be registered');
+        assert.equal(controller.getState().isPinching, false);
+        assert.equal(controller.getState().scale, 2);
+
+        const initialStartScale = controller.getState().touchStartScale;
+
+        for (const handler of touchEndHandlers) {
+            handler({ touches: [] });
+        }
+
+        assert.equal(controller.getState().isPinching, false, 'isPinching stays false');
+        assert.equal(controller.getState().touchStartScale, initialStartScale, 'touchStartScale unchanged for non-pinch touchend');
+    });
 });

--- a/tests/article-progress.test.js
+++ b/tests/article-progress.test.js
@@ -36,7 +36,8 @@ describe('article reading progress', () => {
 
         assert.equal(shouldCollapseTocForViewport(390), true);
         assert.equal(shouldCollapseTocForViewport(767), true);
-        assert.equal(shouldCollapseTocForViewport(768), false);
+        assert.equal(shouldCollapseTocForViewport(768), true);
+        assert.equal(shouldCollapseTocForViewport(769), false);
     });
 
     test('normalizes table of contents entries for rendering', async () => {

--- a/tests/article-selection-toolbar.test.js
+++ b/tests/article-selection-toolbar.test.js
@@ -1,0 +1,226 @@
+import assert from 'node:assert/strict';
+import { describe, test } from 'node:test';
+
+class FakeElement {
+    constructor(tagName, attributes = {}) {
+        this.tagName = tagName.toUpperCase();
+        this.attributes = new Map(Object.entries(attributes));
+        this.children = [];
+        this.parentElement = null;
+        this.dataset = {};
+        this.textContent = '';
+        this.offsetWidth = 132;
+        this.offsetHeight = 40;
+        this.listeners = new Map();
+        this.classNames = new Set();
+        this.classList = {
+            add: (...names) => names.forEach((name) => this.classNames.add(name)),
+            remove: (...names) => names.forEach((name) => this.classNames.delete(name)),
+            contains: (name) => this.classNames.has(name),
+            toggle: (name, force) => {
+                const shouldHave = force ?? !this.classNames.has(name);
+                if (shouldHave) {
+                    this.classNames.add(name);
+                } else {
+                    this.classNames.delete(name);
+                }
+                return shouldHave;
+            },
+        };
+        this.style = {};
+    }
+
+    get className() {
+        return [...this.classNames].join(' ');
+    }
+
+    set className(value) {
+        this.classNames.clear();
+        String(value).split(/\s+/).filter(Boolean).forEach((name) => this.classNames.add(name));
+    }
+
+    append(...children) {
+        children.forEach((child) => this.appendChild(child));
+    }
+
+    appendChild(child) {
+        child.parentElement = this;
+        this.children.push(child);
+        return child;
+    }
+
+    remove() {
+        if (this.parentElement) {
+            this.parentElement.children = this.parentElement.children.filter((c) => c !== this);
+            this.parentElement = null;
+        }
+    }
+
+    setAttribute(name, value) {
+        this.attributes.set(name, String(value));
+    }
+
+    getAttribute(name) {
+        return this.attributes.get(name) ?? null;
+    }
+
+    addEventListener(type, handler) {
+        const handlers = this.listeners.get(type) || [];
+        handlers.push(handler);
+        this.listeners.set(type, handlers);
+    }
+
+    removeEventListener(type, handler) {
+        const handlers = this.listeners.get(type) || [];
+        this.listeners.set(type, handlers.filter((h) => h !== handler));
+    }
+
+    contains(target) {
+        if (target === this) return true;
+        return this.children.some((child) => child.contains(target));
+    }
+
+    closest(selector) {
+        if (selector.startsWith('[data-') && selector.endsWith(']')) {
+            const attr = selector.slice(6, -1);
+            if (this.dataset && attr in this.dataset) {
+                return this;
+            }
+        }
+        return this.parentElement?.closest?.(selector) || null;
+    }
+
+    querySelector(selector) {
+        return this.querySelectorAll(selector)[0] || null;
+    }
+
+    querySelectorAll(selector) {
+        const matches = [];
+        const walk = (node) => {
+            if (selector.startsWith('.') && node.classNames?.has(selector.slice(1))) {
+                matches.push(node);
+            } else if (selector.startsWith('[data-') && selector.endsWith(']')) {
+                const attr = selector.slice(6, -1);
+                if (node.dataset && attr in node.dataset) {
+                    matches.push(node);
+                }
+            }
+            node.children?.forEach((child) => {
+                child.parentElement = node;
+                walk(child);
+            });
+        };
+        walk(this);
+        return matches;
+    }
+}
+
+function createFakeEnvironment({ clipboardWrite } = {}) {
+    const body = new FakeElement('body');
+    const container = new FakeElement('div');
+    body.appendChild(container);
+
+    const fakeDocument = {
+        createElement: (tag) => new FakeElement(tag),
+        querySelector: () => null,
+        addEventListener: () => {},
+        removeEventListener: () => {},
+        body,
+        activeElement: null,
+    };
+    const fakeWindow = {
+        innerWidth: 1024,
+        innerHeight: 768,
+        getSelection: () => null,
+        navigator: {
+            clipboard: clipboardWrite
+                ? { writeText: clipboardWrite }
+                : undefined,
+        },
+        addEventListener: () => {},
+        removeEventListener: () => {},
+        document: fakeDocument,
+    };
+    container.ownerDocument = fakeDocument;
+    fakeDocument.defaultView = fakeWindow;
+
+    return { container, fakeDocument, fakeWindow };
+}
+
+describe('article selection toolbar', () => {
+    test('clipboard rejection does not throw during copy action', async () => {
+        const { initSelectionToolbar } = await import('../src/lib/article-enhancements/selection-toolbar.js');
+        const { container, fakeWindow } = createFakeEnvironment({
+            clipboardWrite: () => Promise.reject(new Error('permission denied')),
+        });
+
+        const cleanup = initSelectionToolbar(container, { windowRef: fakeWindow });
+
+        const toolbar = container.querySelector('.selection-toolbar');
+        assert.ok(toolbar, 'toolbar should be created');
+
+        const unhandledRejections = [];
+        const originalHandler = process.listeners('unhandledRejection');
+        process.on('unhandledRejection', (reason) => {
+            unhandledRejections.push(reason);
+        });
+
+        try {
+            const copyButton = toolbar.children.find((c) => c.dataset?.action === 'copy');
+            assert.ok(copyButton, 'copy button should exist');
+
+            const clickHandlers = toolbar.listeners.get('click');
+            assert.ok(clickHandlers, 'click handlers should be registered');
+
+            fakeWindow.getSelection = () => ({
+                toString: () => 'selected text',
+                rangeCount: 1,
+                anchorNode: container.children[0],
+                getRangeAt: () => ({
+                    getBoundingClientRect: () => ({ left: 100, top: 100, width: 50, height: 20 }),
+                }),
+            });
+
+            for (const handler of clickHandlers) {
+                await handler({ target: copyButton });
+            }
+
+            assert.equal(unhandledRejections.length, 0, 'clipboard rejection should not become unhandled');
+        } finally {
+            process.removeAllListeners('unhandledRejection');
+            originalHandler.forEach((h) => process.on('unhandledRejection', h));
+            cleanup();
+        }
+    });
+
+    test('toolbar hides after copy even when clipboard write fails', async () => {
+        const { initSelectionToolbar } = await import('../src/lib/article-enhancements/selection-toolbar.js');
+        const { container, fakeWindow } = createFakeEnvironment({
+            clipboardWrite: () => Promise.reject(new Error('not allowed')),
+        });
+
+        const cleanup = initSelectionToolbar(container, { windowRef: fakeWindow });
+
+        const toolbar = container.querySelector('.selection-toolbar');
+        toolbar.classNames.add('is-visible');
+
+        fakeWindow.getSelection = () => ({
+            toString: () => 'test',
+            rangeCount: 1,
+            anchorNode: container.children[0],
+            getRangeAt: () => ({
+                getBoundingClientRect: () => ({ left: 100, top: 100, width: 50, height: 20 }),
+            }),
+        });
+
+        const copyButton = toolbar.children.find((c) => c.dataset?.action === 'copy');
+        const clickHandlers = toolbar.listeners.get('click');
+
+        for (const handler of clickHandlers) {
+            await handler({ target: copyButton });
+        }
+
+        assert.equal(toolbar.classNames.has('is-visible'), false, 'toolbar should hide after copy attempt');
+        cleanup();
+    });
+});

--- a/tests/phase-10-integration.test.js
+++ b/tests/phase-10-integration.test.js
@@ -14,6 +14,7 @@ describe('Phase 10 article experience integration', () => {
         const component = readProjectFile('src', 'components', 'ArticleToc.astro');
 
         assert.match(component, /id="article-toc-panel"/);
+        assert.match(component, /role="complementary"/);
         assert.match(component, /data-article-toc-toggle/);
         assert.match(component, /aria-controls="article-toc-panel"/);
         assert.match(component, /aria-expanded="false"/);

--- a/tests/phase-10-integration.test.js
+++ b/tests/phase-10-integration.test.js
@@ -29,4 +29,11 @@ describe('Phase 10 article experience integration', () => {
         assert.match(styles, /\.article-toc-toggle\s*\{[\s\S]*display:\s*none;/);
         assert.match(styles, /@media\s*\(max-width:\s*768px\)\s*\{[\s\S]*\.article-toc-toggle\s*\{[\s\S]*position:\s*fixed;[\s\S]*right:\s*1rem;[\s\S]*bottom:\s*2rem;[\s\S]*width:\s*48px;[\s\S]*height:\s*48px;/);
     });
+
+    test('lightbox exposes custom keyboard shortcuts to assistive technology', () => {
+        const source = readProjectFile('src', 'lib', 'article-enhancements', 'image-lightbox.js');
+
+        assert.match(source, /dialog\.addEventListener\(\s*['"]keydown['"]/);
+        assert.match(source, /dialog\.setAttribute\(\s*['"]aria-keyshortcuts['"]\s*,\s*['"]Escape ArrowLeft ArrowRight \+ -['"]\s*\)/);
+    });
 });

--- a/tests/phase-10-integration.test.js
+++ b/tests/phase-10-integration.test.js
@@ -50,4 +50,16 @@ describe('Phase 10 article experience integration', () => {
         assert.match(styles, /\.selection-toolbar\.is-visible\s*\{[\s\S]*opacity:\s*1;[\s\S]*visibility:\s*visible;/);
         assert.match(styles, /\.selection-toolbar-feedback\s*\{[\s\S]*position:\s*fixed;[\s\S]*bottom:\s*2rem;/);
     });
+
+    test('phase 10 uses vanilla article enhancement modules without new dependencies', () => {
+        const packageJson = JSON.parse(readProjectFile('package.json'));
+        const enhancements = readProjectFile('src', 'lib', 'article-enhancements', 'article-enhancements.js');
+
+        assert.match(enhancements, /initImageLightbox/);
+        assert.match(enhancements, /initReadingProgress/);
+        assert.match(enhancements, /initSelectionToolbar/);
+        assert.equal(packageJson.dependencies.gsap, undefined);
+        assert.equal(packageJson.dependencies['three'], undefined);
+        assert.equal(packageJson.dependencies['@floating-ui/dom'], undefined);
+    });
 });

--- a/tests/phase-10-integration.test.js
+++ b/tests/phase-10-integration.test.js
@@ -36,4 +36,17 @@ describe('Phase 10 article experience integration', () => {
         assert.match(source, /dialog\.addEventListener\(\s*['"]keydown['"]/);
         assert.match(source, /dialog\.setAttribute\(\s*['"]aria-keyshortcuts['"]\s*,\s*['"]Escape ArrowLeft ArrowRight \+ -['"]\s*\)/);
     });
+
+    test('selection toolbar is importable, initialized, and styled', async () => {
+        const mod = await import('../src/lib/article-enhancements/selection-toolbar.js');
+        const enhancements = readProjectFile('src', 'lib', 'article-enhancements', 'article-enhancements.js');
+        const styles = readProjectFile('src', 'styles', 'global.css');
+
+        assert.equal(typeof mod.initSelectionToolbar, 'function');
+        assert.match(enhancements, /import\s+\{\s*initSelectionToolbar\s*\}\s+from\s+['"]\.\/selection-toolbar\.js['"]/);
+        assert.match(enhancements, /selectionToolbarCleanup\s*=\s*initSelectionToolbar\(markdownContent/);
+        assert.match(styles, /\.selection-toolbar\s*\{[\s\S]*position:\s*fixed;[\s\S]*z-index:\s*1000;[\s\S]*opacity:\s*0;/);
+        assert.match(styles, /\.selection-toolbar\.is-visible\s*\{[\s\S]*opacity:\s*1;[\s\S]*visibility:\s*visible;/);
+        assert.match(styles, /\.selection-toolbar-feedback\s*\{[\s\S]*position:\s*fixed;[\s\S]*bottom:\s*2rem;/);
+    });
 });

--- a/tests/phase-10-integration.test.js
+++ b/tests/phase-10-integration.test.js
@@ -1,0 +1,32 @@
+import assert from 'node:assert/strict';
+import { readFileSync } from 'node:fs';
+import path from 'node:path';
+import { describe, test } from 'node:test';
+
+const rootDir = path.resolve(import.meta.dirname, '..');
+
+function readProjectFile(...segments) {
+    return readFileSync(path.join(rootDir, ...segments), 'utf8');
+}
+
+describe('Phase 10 article experience integration', () => {
+    test('article TOC exposes a mobile floating toggle with accessible state', () => {
+        const component = readProjectFile('src', 'components', 'ArticleToc.astro');
+
+        assert.match(component, /id="article-toc-panel"/);
+        assert.match(component, /data-article-toc-toggle/);
+        assert.match(component, /aria-controls="article-toc-panel"/);
+        assert.match(component, /aria-expanded="false"/);
+        assert.match(component, /data-i18n-aria-label="toc\.toggleAria"/);
+        assert.match(component, /data-article-toc-list role="list"/);
+    });
+
+    test('mobile TOC keeps a fixed right-side wiki sidebar posture', () => {
+        const styles = readProjectFile('src', 'styles', 'global.css');
+
+        assert.match(styles, /@media\s*\(max-width:\s*768px\)\s*\{[\s\S]*\.article-toc-shell\s*\{[\s\S]*position:\s*fixed;[\s\S]*right:\s*0;[\s\S]*top:\s*50%;[\s\S]*transform:\s*translateY\(-50%\);/);
+        assert.match(styles, /\.article-toc-shell\.is-collapsed\s*\{[\s\S]*transform:\s*translateY\(-50%\)\s+translateX\(100%\);/);
+        assert.match(styles, /\.article-toc-toggle\s*\{[\s\S]*display:\s*none;/);
+        assert.match(styles, /@media\s*\(max-width:\s*768px\)\s*\{[\s\S]*\.article-toc-toggle\s*\{[\s\S]*position:\s*fixed;[\s\S]*right:\s*1rem;[\s\S]*bottom:\s*2rem;[\s\S]*width:\s*48px;[\s\S]*height:\s*48px;/);
+    });
+});


### PR DESCRIPTION
## Summary

Phase 10 improves the article reading experience with accessibility enhancements, keyboard navigation, mobile-optimized TOC, and a text selection toolbar.

### Features (7 commits)
- **Mobile TOC**: Fixed right-side wiki sidebar style with floating toggle button
- **Lightbox pinch-to-zoom**: Ratio-based scaling (no incremental drift), transform origin tracks touch center
- **Lightbox keyboard shortcuts**: Tab focus trap, Escape/ArrowLeft/ArrowRight/+/- shortcuts
- **TOC keyboard navigation**: Arrow keys cycle through links, Enter activates
- **Selection toolbar**: Copy selected text or share a link to the nearest heading
- **Screen reader support**: ARIA labels, roles, and dialog semantics throughout

### Code Review Fixes (2 commits)
- Guard lightbox touchend from resetting 	ouchStartScale on single-finger release
- Replace clampScale with dedicated clamp for percentage clamping
- Wrap writeClipboard in try/catch so clipboard rejection doesn't become unhandled
- Isolate enhancement cleanup chain so one failing cleanup doesn't skip the rest

### Tests
- 228/228 passing (3 new tests added)
- New rticle-selection-toolbar.test.js for clipboard error handling
- New lightbox test for touchend isPinching guard

### Files Changed
- src/components/ArticleToc.astro — mobile toggle button with ARIA
- src/lib/article-enhancements/image-lightbox.js — pinch zoom, keyboard, accessibility
- src/lib/article-enhancements/heading-index.js — TOC keyboard nav + accessibility
- src/lib/article-enhancements/reading-progress.js — mobile TOC state sync
- src/lib/article-enhancements/selection-toolbar.js — NEW: copy/share toolbar
- src/lib/article-enhancements/article-enhancements.js — cleanup chain isolation
- src/styles/global.css — mobile TOC, selection toolbar, focus styles
- src/i18n/zh-CN.json + src/i18n/en-US.json — new UI strings